### PR TITLE
修复多卡训练BUG

### DIFF
--- a/mvector/trainer.py
+++ b/mvector/trainer.py
@@ -53,9 +53,7 @@ class MVectorTrainer(object):
         assert self.configs.use_model in SUPPORT_MODEL, f'没有该模型：{self.configs.use_model}'
         self.model = None
         self.test_loader = None
-        # 获取特征器
-        self.audio_featurizer = AudioFeaturizer(feature_conf=self.configs.feature_conf, **self.configs.preprocess_conf)
-        self.audio_featurizer.to(self.device)
+
         if platform.system().lower() == 'windows':
             self.configs.dataset_conf.num_workers = 0
             logger.warning('Windows系统不支持多线程读取数据，已自动关闭！')
@@ -302,6 +300,9 @@ class MVectorTrainer(object):
             dist.init_process_group(backend='nccl')
             local_rank = int(os.environ["LOCAL_RANK"])
 
+        # 获取特征器
+        self.audio_featurizer = AudioFeaturizer(feature_conf=self.configs.feature_conf, **self.configs.preprocess_conf)
+        self.audio_featurizer.to(local_rank)
         # 获取数据
         self.__setup_dataloader(augment_conf_path=augment_conf_path, is_train=True)
         # 获取模型


### PR DESCRIPTION
多卡训练时确保特征器与音频数据在同一个GPU中。否则报错类似：
(torchaudio) stft input and window must be on the same device but got self on cuda:1 and window on cuda:0